### PR TITLE
删除冗余引入+ ts类型定义报错修复

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,11 +2,12 @@ import Theme from 'vitepress/theme'
 import './demo-block.scss'
 import {registerComponents} from './register-components'
 import SheepUI from '../../../src/index'
+import type {App} from 'vue'
 
 export default {
   ...Theme,
   // 扩展应用程序实例
-  enhanceApp({app}) {
+  enhanceApp({app}:{app:App<never>}) {
     // 注册组件
     registerComponents(app)
     app.use(SheepUI)

--- a/docs/.vitepress/theme/register-components.ts
+++ b/docs/.vitepress/theme/register-components.ts
@@ -1,6 +1,7 @@
 import Demo from 'vitepress-theme-demoblock/components/Demo.vue'
 import DemoBlock from 'vitepress-theme-demoblock/components/DemoBlock.vue'
-export function registerComponents(app) {
+import type {App} from 'vue'
+export function registerComponents(app:App<never>) {
   app.component('Demo', Demo)
   app.component('DemoBlock', DemoBlock)
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
 // This starter template is using Vue 3 <script setup> SFCs
 // Check out https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup
-import { AlignCenterIcon } from './icon/align-center/align-center'
-import { UserIcon } from './icon/user/user'
-import { InfoCircleIcon } from './icon/info-circle/info-circle'
-import { ref } from 'vue'
-const text = ref('')
 </script>
 
 <template>

--- a/src/tree/src/tree-type.ts
+++ b/src/tree/src/tree-type.ts
@@ -1,4 +1,4 @@
-import { ExtractPropTypes, PropType } from 'vue'
+import { ExtractPropTypes } from 'vue'
 
 export const treeProps = {} as const
 export type TreeProps = ExtractPropTypes<typeof treeProps>


### PR DESCRIPTION
before:

https://github.com/57code/sheep-ui/blob/master/docs/.vitepress/theme/index.ts#L9
与
https://github.com/57code/sheep-ui/blob/master/docs/.vitepress/theme/register-components.ts#L3
中，打开文件，TS会报错：绑定元素“app”隐式具有“any”类型。ts(7031)

于是添加了类型定义。