### PR TITLE
fix: 锁定vitepress版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tailwindcss": "^3.1.6",
     "typescript": "^4.6.4",
     "vite": "^3.0.0",
-    "vitepress": "^1.0.0-alpha.4",
+    "vitepress": "1.0.0-alpha.8",
     "vitepress-theme-demoblock": "^1.4.2",
     "vitest": "^0.19.0",
     "vue-tsc": "^0.38.4"


### PR DESCRIPTION
项目clone后启动不了，发现问题主要在vitepress中的`<script setup>`中。

爬了会坑定位到是`vitepress-theme-demoblock`尝试读取在vitepress新版被移除的`hoistedTags`属性。

见：
https://github.com/vuejs/vitepress/issues/1258

`vitepress-theme-demoblock`项目看上去好像没有维护了，看了下去原仓库提这个bug不大可能被修复了。

只能先锁死版本到`vitepress 1.0.0-alpha.8`来解决一下了。